### PR TITLE
sync recipe with AnacondaRecipes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,13 +9,13 @@ environment:
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
 
   matrix:
-    - CONFIG: win_python2.7
+    - CONFIG: win_c_compilervs2008python2.7
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_python3.5
+    - CONFIG: win_c_compilervs2015python3.5
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_python3.6
+    - CONFIG: win_c_compilervs2015python3.6
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -1,4 +1,10 @@
+c_compiler:
+- toolchain_c
+libxml2:
+- '2.9'
 pin_run_as_build:
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -1,4 +1,10 @@
+c_compiler:
+- toolchain_c
+libxml2:
+- '2.9'
 pin_run_as_build:
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -1,10 +1,16 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+c_compiler:
+- toolchain_c
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -1,10 +1,16 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+c_compiler:
+- toolchain_c
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -1,10 +1,16 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
+c_compiler:
+- toolchain_c
+libxml2:
+- '2.9'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
 pin_run_as_build:
+  libxml2:
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_c_compilervs2008python2.7.yaml
+++ b/.ci_support/win_c_compilervs2008python2.7.yaml
@@ -1,5 +1,5 @@
 c_compiler:
-- toolchain_c
+- vs2008
 libxml2:
 - '2.9'
 pin_run_as_build:
@@ -10,3 +10,6 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '2.7'
+zip_keys:
+- - python
+  - c_compiler

--- a/.ci_support/win_c_compilervs2015python3.5.yaml
+++ b/.ci_support/win_c_compilervs2015python3.5.yaml
@@ -1,5 +1,5 @@
 c_compiler:
-- toolchain_c
+- vs2015
 libxml2:
 - '2.9'
 pin_run_as_build:
@@ -9,4 +9,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.5'
+zip_keys:
+- - python
+  - c_compiler

--- a/.ci_support/win_c_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015python3.6.yaml
@@ -1,5 +1,5 @@
 c_compiler:
-- toolchain_c
+- vs2015
 libxml2:
 - '2.9'
 pin_run_as_build:
@@ -9,4 +9,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '2.7'
+- '3.6'
+zip_keys:
+- - python
+  - c_compiler

--- a/.ci_support/win_python2.7.yaml
+++ b/.ci_support/win_python2.7.yaml
@@ -1,6 +1,0 @@
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- '2.7'

--- a/.ci_support/win_python3.5.yaml
+++ b/.ci_support/win_python3.5.yaml
@@ -1,6 +1,0 @@
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- '3.5'

--- a/.ci_support/win_python3.6.yaml
+++ b/.ci_support/win_python3.6.yaml
@@ -1,6 +1,0 @@
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- '3.6'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,14 @@ build:
     - python -m pip install --no-deps --ignore-installed .  # [win]
 
 requirements:
-  build:
+  host:
     - python
     - pip
     - cython
     - libxml2 2.9.*
     - libxslt
+  build:
+    - {{ compiler('c') }}
   run:
     - python
     - libxml2 2.9.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ about:
     mostly compatible but superior to the well-known ElementTree API.
   doc_url: 'http://lxml.de/index.html#documentation'
   dev_url: https://github.com/lxml/lxml
+  doc_source_url: https://github.com/lxml/lxml/tree/master/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,17 +15,16 @@ build:
     - python -m pip install --no-deps --ignore-installed .  # [win]
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
+    - libxml2
     - python
     - pip
     - cython
-    - libxml2 2.9.*
     - libxslt
-  build:
-    - {{ compiler('c') }}
   run:
     - python
-    - libxml2 2.9.*
     - libxslt
 
 test:


### PR DESCRIPTION
Add compiler jinja for use with conda build 3.
Remove libxml2 pinning which is now supplied by the conda_build_config.yaml file in conda-forge-pinning.
Add entry to the about section.